### PR TITLE
Added 52 week commit stats column

### DIFF
--- a/website/src/helpers/content_helper.rb
+++ b/website/src/helpers/content_helper.rb
@@ -72,7 +72,11 @@ module ContentHelper
         test_info[:image] = "https://secure.travis-ci.org/#{user}/#{project}.png?branch=master"
       end
 
-      yield i+1,plugin[:downloads90],plugin[:downloads],name,plugin[:status],version,released,normalize(descr),cite,plugin[:authors].join(', '),home,docs,src,issues,num_issues,test_info,commit,trend_direction,rank90[name]
+      if plugin[:commit_stats]
+        stats = generate_52week_graph(plugin[:commit_stats])
+      end
+
+      yield i+1,plugin[:downloads90],plugin[:downloads],name,plugin[:status],version,released,normalize(descr),cite,plugin[:authors].join(', '),home,docs,src,issues,num_issues,test_info,commit,trend_direction,rank90[name],stats
     end
   end
 
@@ -100,6 +104,14 @@ module ContentHelper
     end
     return (days/365).to_i.to_s+' years'
 
+  end
+
+  def generate_52week_graph stats
+    boxes = ["\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"]
+    graph_array = stats.map do |commits|
+      boxes[commits > 7 ? 7 : commits]
+    end
+    graph_array.join
   end
 
 end

--- a/website/src/pages/index.haml
+++ b/website/src/pages/index.haml
@@ -23,7 +23,8 @@
         %th.commit{ :align => "left" } commit
         %th.dl{ :align => "left" } dl*)
         %th.dl{ :align => "left" } 90d*)
-      - by_popularity do |i, dl90, dl, name, status, version, released, descr, cite, author, home, docs, src, issues, num_issues, test_info, commit, trend_direction, rank90|
+        %th.stats 52 week commit stats
+      - by_popularity do |i, dl90, dl, name, status, version, released, descr, cite, author, home, docs, src, issues, num_issues, test_info, commit, trend_direction, rank90, stats|
         - rowclass = "odd"
         - if i.even?
           - rowclass = "even"
@@ -101,6 +102,9 @@
           %td{ :align => "right", :class => "#{rowclass}" }
             .dl
               = dl90.to_s
+          %td{ :class => "#{rowclass}" }
+            .stats
+              = stats
   .footnote 
     <b>*)</b> gem downloads (dl total &amp; dl last 90 days) from 
     = link "rubygems.org", "http://rubygems.org"

--- a/website/src/stylesheets/screen.sass
+++ b/website/src/stylesheets/screen.sass
@@ -110,6 +110,14 @@ body
     .dl
       font:
         size: small
+    th.stats
+      font:
+        size: small
+    td
+      .stats
+        font-family: "Nimbus Mono L"
+        font-size: small
+
 
 
 .footnote


### PR DESCRIPTION
The current implementation generates the graph using a few special Unicode chars: ▁ ▂ ▃ ▄ ▅ ▆ ▇ █ 

I had a problem with those chars because they weren't the same width in Chrome on Ubuntu, but managed to fix that using a different font. In case other people have similar problems, we can add other fonts into the list in CSS. Or we can recreate the functionality using JS and/or canvas.
