### PR TITLE
Fixed code for the case when participation data is not retrieved

### DIFF
--- a/bin/list-bio.rb
+++ b/bin/list-bio.rb
@@ -133,9 +133,11 @@ def get_github_commit_stats github_uri
     body = "{}"
   end
   stats = JSON.parse(body)
-  stats = {"all"=>[]} if stats == {}
-  $stderr.print stats['all'].size, "\n"
-  stats['all']
+  if stats.empty?
+    return nil
+  else
+    return stats['all']
+  end
 end
 
 def update_status(projects)


### PR DESCRIPTION
The code now tries again if the participation data is not retrieved, and in case the second attempt fails too, it degrades to no commit data from GitHub, e.g. empty box.
