### PR TITLE
make check_url follow 301 redirect

### DIFF
--- a/bin/list-bio.rb
+++ b/bin/list-bio.rb
@@ -58,7 +58,12 @@ def check_url url
       if response.code.to_i == 200 and response.body !~ /301 Moved/
         $stderr.print "pass!\n"
         return url
+      elsif response.code.to_i == 301
+        raise LoadError
       end
+    rescue LoadError
+      url = response['location']
+      retry
     rescue
       $stderr.print $!
     end


### PR DESCRIPTION
Website for some gems (SequenceServer, for example) employ a 301 redirect to
direct the user to the actual home page.  Failing to follow redirects, when
checking validity of a URL (in the `check_url` method), causes Biogems.info to
use the rubydoc.info page for the gem as the project home page, which may not
always be desirable.
