### PR TITLE
Remove links in download stats

### DIFF
--- a/website/src/pages/index.haml
+++ b/website/src/pages/index.haml
@@ -113,10 +113,10 @@
           //        %img#git{:src => "/images/git-logo.png", :width=>"80", :alt => "github"}
           %td{ :align => "right", :class => "#{rowclass}" }
             .dl
-              = link dl.to_s, "http://rubygems.org/gems/#{name}/stats"
+              = dl.to_s
           %td{ :align => "right", :class => "#{rowclass}" }
             .dl
-              = link dl90.to_s, "http://rubygems.org/gems/#{name}/stats"
+              = dl90.to_s
           %td{ :align => "right", :class => "#{rowclass}", :style => "background: #{c7_color}" }
             .commits
               - if src =~ /git/


### PR DESCRIPTION
The website currently adds a link to the download stats using a string in the form of: `"http://rubygems.org/gems/#{gemname}/stats"`
which results in a 404 when clicked.
