### PR TITLE
Removed statement "over a century"

### DIFF
--- a/doc/abstracts/BOSC2014_BioRuby_dev.md
+++ b/doc/abstracts/BOSC2014_BioRuby_dev.md
@@ -2,8 +2,7 @@
 
 With the distributed development of biogems, as listed on http://biogems.info/,
 the BioRuby community is one of the most active Open Bioinformatics Foundation
-communities in terms of number of projects (over a century now), git commits and
-library downloads.
+communities in terms of number of projects, git commits and library downloads.
 
 In this talk we will quantify and visualize what it means to allow contributing
 independent small modules and tools to the bioinformatics community. Not only


### PR DESCRIPTION
Perhaps "decade" was meant, but I think it reads nicer without the statement at all. A comment could be added that BioRuby is a mature product and was founded over a decade ago, even though that is not necessary in my opinion.
