### PR TITLE
Add ncbi-blast-dbs gem.

### DIFF
--- a/etc/biogems/ncbi-blast-dbs.yaml
+++ b/etc/biogems/ncbi-blast-dbs.yaml
@@ -1,0 +1,2 @@
+:status: beta
+:source_code_uri: https://github.com/yeban/ncbi-blast-dbs


### PR DESCRIPTION
A small (< 70 lines, including comments) tool to download BLAST databases from NCBI, faster than update_blastdb.pl.
